### PR TITLE
Add locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ zfs-cleaner has a single mandatory argument. The path to a configuration file.
 
 A few flags are provided as well.
 
-| Short | Long        | Description                                  |  
-|-------|-------------|----------------------------------------------|
-| `-n`  | `--dryrun`  | Do nothing, print what could have been done. |
-| `-v`  | `--verbose` | Do everything, print what's done.            |
+| Short | Long           | Description                                                                               |
+|-------|----------------|-------------------------------------------------------------------------------------------|
+| `-n`  | `--dryrun`     | Do nothing, print what could have been done.                                              |
+| `-v`  | `--verbose`    | Do everything, print what's done.                                                         |
+| `-c`  | `--concurrent` | Allow more than one zfs-cleaner to operate on the same configuration file simultaneously. |


### PR DESCRIPTION
This PR will add locking to zfs-cleaner. zfs-cleaner will try to lock the configuration file when executing. As default it will exit if it cannot acquire the lock.

This will be useful when running periodically from crond.

A new flag `-c` allows for multiple zfs-cleaners to operate on the same configuration file.