### PR TITLE
Plancheck

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     locale-gen en_GB.UTF-8
-    add-apt-repository ppa:longsleep/golang-backports
+
     apt-get update
     apt-get install -y zfsutils-linux zfs-initramfs
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,63 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    locale-gen en_GB.UTF-8
+    add-apt-repository ppa:longsleep/golang-backports
+    apt-get update
+    apt-get install -y zfsutils-linux zfs-initramfs
+
+    mkdir -p /zfsmnt/
+
+    dd if=/dev/zero of=/zfsmnt/disk0 bs=1M count=128
+    dd if=/dev/zero of=/zfsmnt/disk1 bs=1M count=128
+    dd if=/dev/zero of=/zfsmnt/disk2 bs=1M count=128
+    losetup /dev/loop0 /zfsmnt/disk0
+    losetup /dev/loop1 /zfsmnt/disk1
+    losetup /dev/loop2 /zfsmnt/disk2
+
+    zpool create -f datastore0 raidz /dev/loop0 /dev/loop1 /dev/loop2
+
+    dd if=/dev/zero of=/zfsmnt/disk3 bs=1M count=128
+    dd if=/dev/zero of=/zfsmnt/disk4 bs=1M count=128
+    losetup /dev/loop3 /zfsmnt/disk3
+    losetup /dev/loop4 /zfsmnt/disk4
+
+    zpool create -f datastore1 raidz /dev/loop3 /dev/loop4
+
+    dd if=/dev/zero of=/zfsmnt/disk5 bs=1M count=128
+    dd if=/dev/zero of=/zfsmnt/disk6 bs=1M count=128
+    dd if=/dev/zero of=/zfsmnt/disk7 bs=1M count=128
+    losetup /dev/loop5 /zfsmnt/disk5
+    losetup /dev/loop6 /zfsmnt/disk6
+    losetup /dev/loop7 /zfsmnt/disk7
+
+    zpool create -f datastore2 raidz /dev/loop5 /dev/loop6 /dev/loop7
+
+    cat << EOF > plan
+plan planA {
+  path datastore0
+  path datastore1
+
+  keep latest 2
+
+  keep 1m for 2h
+  keep 1h for 2d
+}
+
+plan planB {
+  path datastore2
+
+  keep latest 10
+}
+
+EOF
+
+  echo 'You can now run "GOOS=linux go build && GOOS=linux go test -c" from the host'
+  echo 'and run "/vagrant/zfs-cleaner plan" in the box'
+  SHELL
+end

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func planCheck(conf *conf.Config) error {
 
 	for _, store := range strings.Fields(string(output)) {
 		if !m[store] {
-			fmt.Printf("No plan found for path: %s\n", store)
+			fmt.Printf("No plan found for path: '%s'\n", store)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&dryrun, "dryrun", "n", false, "Do nothing destructive, only print")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Be more verbose")
 	rootCmd.PersistentFlags().BoolVarP(&concurrent, "concurrent", "c", false, "Allow more than one zfs-cleaner to operate on the same configuration file simultaneously")
+	rootCmd.TraverseChildren = true
 }
 
 func getList(name string) (zfs.SnapshotList, error) {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ var (
 	verbose    = false
 	dryrun     = false
 	concurrent = false
-	plancheck  = false
 
 	commandName      = "/sbin/zfs"
 	commandArguments = []string{"list", "-t", "snapshot", "-o", "name,creation", "-s", "creation", "-r", "-H", "-p"}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -17,6 +18,7 @@ var (
 	verbose    = false
 	dryrun     = false
 	concurrent = false
+	plancheck  = false
 
 	commandName      = "/sbin/zfs"
 	commandArguments = []string{"list", "-t", "snapshot", "-o", "name,creation", "-s", "creation", "-r", "-H", "-p"}
@@ -41,6 +43,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&dryrun, "dryrun", "n", false, "Do nothing destructive, only print")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Be more verbose")
 	rootCmd.PersistentFlags().BoolVarP(&concurrent, "concurrent", "c", false, "Allow more than one zfs-cleaner to operate on the same configuration file simultaneously")
+	rootCmd.PersistentFlags().BoolVarP(&plancheck, "plancheck", "p", false, "Print mounts that have no plan and exit")
 }
 
 func getList(name string) (zfs.SnapshotList, error) {
@@ -88,6 +91,29 @@ func processAll(now time.Time, conf *conf.Config) ([]zfs.SnapshotList, error) {
 	return lists, nil
 }
 
+func planCheck(conf *conf.Config) error {
+	args := []string{"list", "-t", "filesystem", "-o", "name", "-H"}
+	output, err := exec.Command(commandName, args...).Output()
+	if err != nil {
+		return err
+	}
+
+	m := map[string]bool{}
+	for _, plan := range conf.Plans {
+		for _, path := range plan.Paths {
+			m[path] = true
+		}
+	}
+
+	for _, store := range strings.Fields(string(output)) {
+		if !m[store] {
+			fmt.Printf("No plan found for path: %s\n", store)
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	err := rootCmd.Execute()
 	if err != nil {
@@ -125,6 +151,10 @@ func clean(cmd *cobra.Command, args []string) error {
 
 		// make sure to unlock :)
 		defer syscall.Flock(fd, syscall.LOCK_UN)
+	}
+
+	if plancheck {
+		return planCheck(conf)
 	}
 
 	lists, err := processAll(now, conf)

--- a/plancheck.go
+++ b/plancheck.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cego/zfs-cleaner/conf"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(plancheckCmd)
+}
+
+var plancheckCmd = &cobra.Command{
+	Use:   "plancheck [config file]",
+	Short: "Print mounts that have no plan and exit",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("%s /path/to/config.conf", cmd.Name())
+		}
+
+		confFile, err := os.Open(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to open %s: %s", args[0], err.Error())
+		}
+		defer confFile.Close()
+
+		conf, err := readConf(confFile)
+		if err != nil {
+			return err
+		}
+		return planCheck(conf)
+	},
+}
+
+func planCheck(conf *conf.Config) error {
+	args := []string{"list", "-t", "filesystem", "-o", "name", "-H"}
+	output, err := exec.Command(commandName, args...).Output()
+	if err != nil {
+		return err
+	}
+
+	m := map[string]bool{}
+	for _, plan := range conf.Plans {
+		for _, path := range plan.Paths {
+			m[path] = true
+		}
+	}
+
+	for _, store := range strings.Fields(string(output)) {
+		if !m[store] {
+			fmt.Printf("No plan found for path: '%s'\n", store)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This introduces the flag `-p` that checks if there is any mount point on the system that does not have a zfs-cleaner plan associated with it.

A simple vagrant script is included to make it easy to get a system with some zfs pools up and running for development.