### PR TITLE
Made tests a lot less talkative

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -34,6 +35,10 @@ var (
 		Short: "Tool for destroying ZFS snapshots after predefined retention periods",
 		RunE:  clean,
 	}
+
+	// Can be overridden when running tests.
+	stdout io.Writer = os.Stdout
+	stderr io.Writer = os.Stderr
 )
 
 func init() {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,12 @@ import (
 
 func init() {
 	panicBail = true
+
+	// Mute normal output when running tests.
+	stdout = ioutil.Discard
+	stderr = ioutil.Discard
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
 }
 
 func TestGetList(t *testing.T) {

--- a/todo.go
+++ b/todo.go
@@ -32,17 +32,17 @@ func newComment(format string, args ...interface{}) todo {
 
 func (t *todo) Do() error {
 	if verbose && t.comment != "" {
-		fmt.Printf("### %s\n", t.comment)
+		fmt.Fprintf(stdout, "### %s\n", t.comment)
 	}
 
 	if (verbose || dryrun) && t.command != "" {
-		fmt.Printf("# Running '%s %s'\n", t.command, strings.Join(t.args, " "))
+		fmt.Fprintf(stdout, "# Running '%s %s'\n", t.command, strings.Join(t.args, " "))
 	}
 
 	if !dryrun && t.command != "" {
 		output, err := exec.Command(t.command, t.args...).Output()
 
-		fmt.Print(string(output))
+		fmt.Fprintf(stdout, "%s", string(output))
 
 		if err != nil {
 			return err

--- a/zfs/SnapshotList.go
+++ b/zfs/SnapshotList.go
@@ -37,7 +37,7 @@ func NewSnapshotListFromOutput(output []byte, name string) (SnapshotList, error)
 		}
 
 		if lastCreation.Sub(s.Creation) > time.Second {
-			return nil, fmt.Errorf("output does not appear sorted. %d < %d", s.Creation, lastCreation)
+			return nil, fmt.Errorf("output does not appear sorted. %d < %d", s.Creation.Unix(), lastCreation.Unix())
 		}
 
 		lastCreation = s.Creation


### PR DESCRIPTION
This PR will remove all output for human consumption from `go test` - unless a test fails.

This will make it much easier to grasp test output.