### PR TITLE
Add protect

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,25 @@ A plan is defined like this:
         path pool/dataset3
 
         keep latest 10
+        protect </etc/<zfs-cleaner.protected
     }
 
     plan planC {
         path pool/dataset4
 
         keep 0s for 1h
+        protect synced_to_remote
     }
 
 *planA* will keep snapshots one minute apart for two hours and one hour apart
 for two days. This will be applied to the dataset *pool/dataset1* and
 *pool/dataset2*. Besides that the latest two snapshots will be kept.
 
-*planB* will keep the ten latest snapshots from *pool/dataset3*.
+*planB* will keep the ten latest snapshots from *pool/dataset3* - but never
+destroy any snapshot name read from `/etc/<zfs-cleaner.protected`.
 
-*planC* will keep all snapshots for an hour.
+*planC* will keep all snapshots for an hour, and any snapshot named
+`synced_to_remote` will be kept forever.
 
 Path must refer to one of the results from `sudo zfs list -t filesystem -o name`.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A plan is defined like this:
         path pool/dataset3
 
         keep latest 10
-        protect </etc/<zfs-cleaner.protected
+        protect </etc/zfs-cleaner.protected
     }
 
     plan planC {
@@ -70,7 +70,7 @@ for two days. This will be applied to the dataset *pool/dataset1* and
 *pool/dataset2*. Besides that the latest two snapshots will be kept.
 
 *planB* will keep the ten latest snapshots from *pool/dataset3* - but never
-destroy any snapshot name read from `/etc/<zfs-cleaner.protected`.
+destroy any snapshot name read from `/etc/zfs-cleaner.protected`.
 
 *planC* will keep all snapshots for an hour, and any snapshot named
 `synced_to_remote` will be kept forever.

--- a/conf/Config_test.go
+++ b/conf/Config_test.go
@@ -90,6 +90,8 @@ path /buh
 path /buh/2
 keep 1d for 30d
 keep 1h for 1d
+protect horse
+protect sheep
 }`, "", &Config{
 			Plans: []Plan{
 				Plan{
@@ -105,6 +107,10 @@ keep 1h for 1d
 							Frequency: time.Hour,
 							Age:       24 * time.Hour,
 						},
+					},
+					Protect: []string{
+						"horse",
+						"sheep",
 					},
 				},
 			},

--- a/conf/Plan_test.go
+++ b/conf/Plan_test.go
@@ -2,6 +2,8 @@ package conf
 
 import (
 	"bufio"
+	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -176,6 +178,100 @@ func TestPathError(t *testing.T) {
 
 		if ret != nil {
 			t.Fatalf("%d path() returned an action", i)
+		}
+	}
+}
+
+func TestProtect(t *testing.T) {
+	c := &Config{}
+	s := &state{}
+	p := &Plan{
+		Name: "testplan",
+		conf: c,
+	}
+
+	cases := []string{"protect tank@s1", "protect tank@s2"}
+	for i, cc := range cases {
+		s.scanner = bufio.NewScanner(strings.NewReader(cc))
+		s.scanLine()
+
+		ret := p.protect(s)
+
+		if s.err != nil {
+			t.Fatalf("%d protect() returned unexpected error: %s", i, s.err.Error())
+		}
+
+		if ret == nil {
+			t.Fatalf("%d protect() did not return action", i)
+		}
+	}
+}
+
+func TestProtectFile(t *testing.T) {
+	d, _ := ioutil.TempDir("", "")
+	f, err := ioutil.TempFile(d, "zfs-cleaner-test")
+	if err != nil {
+		panic(err.Error())
+	}
+	defer f.Close()
+
+	cases := []struct {
+		file     string
+		expected []string
+	}{
+		{"", nil},
+		{"test1", []string{"test1"}},
+		{"test1\ntest2", []string{"test1", "test2"}},
+		{"test1\ntest2", []string{"test1", "test2"}},
+	}
+
+	for i, cc := range cases {
+		var res []string
+		err = f.Truncate(0)
+		if err != nil {
+			t.Fatalf("Error: %s", err.Error())
+		}
+
+		_, _ = f.Seek(0, 0)
+
+		_, err = f.WriteString(cc.file)
+		if err != nil {
+			t.Fatalf("Error: %s", err.Error())
+		}
+
+		readFile(&state{}, f.Name(), &res, nil)
+
+		if !reflect.DeepEqual(res, cc.expected) {
+			t.Fatalf("%d protect() did not set expected values expected [%v], got [%v]", i, cc.expected, res)
+		}
+	}
+}
+
+func TestProtectFileError(t *testing.T) {
+	c := &Config{}
+	s := &state{}
+	p := &Plan{
+		Name: "testplan",
+		conf: c,
+	}
+
+	cases := []string{
+		"protected </",           // directory
+		"protected </etc/shadow", // permission denied
+	}
+
+	for i, cc := range cases {
+		s.scanner = bufio.NewScanner(strings.NewReader(cc))
+		s.scanLine()
+
+		ret := p.protect(s)
+
+		if s.err == nil {
+			t.Fatalf("%d protect() did not return an error", i)
+		}
+
+		if ret != nil {
+			t.Fatalf("%d protect() returned an action", i)
 		}
 	}
 }

--- a/conf/identifiers.go
+++ b/conf/identifiers.go
@@ -1,9 +1,10 @@
 package conf
 
 const (
-	planIdentifier = "plan"
-	keepIdentifier = "keep"
-	pathIdentifier = "path"
+	planIdentifier    = "plan"
+	keepIdentifier    = "keep"
+	pathIdentifier    = "path"
+	protectIdentifier = "protect"
 )
 
 const (

--- a/example.conf
+++ b/example.conf
@@ -26,6 +26,9 @@ plan longlived { # Plans have names. These names are not used for anything for n
 
 	# Keep yearly snapshots for a century.
 	keep 1y for 100y
+
+	protect </etc/zfs-cleaner.protected
+	protect this-is-a-protected-snapshot
 }
 
 # This plan will only save snapshots for 12 hours.

--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func processAll(now time.Time, conf *conf.Config) ([]zfs.SnapshotList, error) {
 				return nil, err
 			}
 
+			list.KeepNamed(plan.Protect)
+
 			list.KeepLatest(plan.Latest)
 			for _, period := range plan.Periods {
 				start := now.Add(-period.Age)

--- a/zfs/Snapshot.go
+++ b/zfs/Snapshot.go
@@ -55,3 +55,14 @@ func NewSnapshotFromLine(line string) (*Snapshot, error) {
 func (s *Snapshot) String() string {
 	return fmt.Sprintf("%s:%d:%v", s.Name, s.Creation.Unix(), s.Keep)
 }
+
+// SnapshotName returns the snapshot name part of the full name. This is the
+// part after the @.
+func (s *Snapshot) SnapshotName() string {
+	parts := strings.Split(s.Name, "@")
+	if len(parts) != 2 {
+		return s.Name
+	}
+
+	return parts[1]
+}

--- a/zfs/SnapshotList.go
+++ b/zfs/SnapshotList.go
@@ -111,7 +111,9 @@ func (l SnapshotList) KeepNamed(names []string) {
 	}
 
 	for _, snapshot := range l {
-		snapshot.Keep = index[snapshot.SnapshotName()]
+		if index[snapshot.SnapshotName()] {
+			snapshot.Keep = true
+		}
 	}
 }
 

--- a/zfs/SnapshotList.go
+++ b/zfs/SnapshotList.go
@@ -102,6 +102,19 @@ func (l SnapshotList) KeepLatest(num int) {
 	}
 }
 
+// KeepNamed will keep all snapshots named in names.
+func (l SnapshotList) KeepNamed(names []string) {
+	// Start by indexing names for lookups.
+	index := make(map[string]bool)
+	for _, name := range names {
+		index[name] = true
+	}
+
+	for _, snapshot := range l {
+		snapshot.Keep = index[snapshot.SnapshotName()]
+	}
+}
+
 // KeepOldest keeps the num oldest snapshots.
 func (l SnapshotList) KeepOldest(num int) {
 	for i := 0; i < num && i < len(l); i++ {

--- a/zfs/SnapshotList_test.go
+++ b/zfs/SnapshotList_test.go
@@ -256,3 +256,25 @@ func TestSieve(t *testing.T) {
 		testKeep(i, t, input, c.expected)
 	}
 }
+
+func TestKeepNamed(t *testing.T) {
+	cases := []struct {
+		names    []string
+		expected []bool
+	}{
+		{[]string{"s1"}, []bool{true, false, false}},
+		{[]string{"s2"}, []bool{false, true, false}},
+		{[]string{"s3"}, []bool{false, false, true}},
+		{[]string{"s1", "s3"}, []bool{true, false, true}},
+		{[]string{}, []bool{false, false, false}},
+		{nil, []bool{false, false, false}},
+		{[]string{"nonexisting"}, []bool{false, false, false}},
+		{[]string{""}, []bool{false, false, false}},
+	}
+
+	for ii, c := range cases {
+		list.ResetSieve()
+		list.KeepNamed(c.names)
+		testKeep(ii, t, list, c.expected)
+	}
+}

--- a/zfs/Snapshot_test.go
+++ b/zfs/Snapshot_test.go
@@ -46,3 +46,25 @@ func TestNewSnapshotFromLine(t *testing.T) {
 		}
 	}
 }
+
+func TestSnapshotName(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"path@s1", "s1"},
+		{"s1", "s1"},
+		{"@s1", "s1"},
+		{"@", ""},
+	}
+
+	for i, c := range cases {
+		s := &Snapshot{
+			Name: c.input,
+		}
+		result := s.SnapshotName()
+		if result != c.expected {
+			t.Fatalf("%d Got wrong name from '%s', expected '%s', got '%s'", i, c.input, c.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
This PR will add a `protect` keyword to plans.

This will enable the user to protect one or more snapshots from destruction. The keyword support two formats:

`protect snapshot-name` - this will protect the snapshot named `snapshot-name` from destruction.

and

`protect </full/path/to/file` - this will read snapshot names from `/full/path/to/file` and protect them from destruction. Both formats can be combined in the same plan. Both keywords can be used multiple times in the same plan.