### PR TITLE
Add --ignore-empty to plancheck

### DIFF
--- a/plancheck.go
+++ b/plancheck.go
@@ -11,32 +11,47 @@ import (
 )
 
 func init() {
+	ignoreEmpty := false
+	plancheckCmd := &cobra.Command{
+		Use:   "plancheck [config file]",
+		Short: "Print mounts that have no plan and exit",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("%s /path/to/config.conf", cmd.Name())
+			}
+
+			confFile, err := os.Open(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to open %s: %s", args[0], err.Error())
+			}
+			defer confFile.Close()
+
+			conf, err := readConf(confFile)
+			if err != nil {
+				return err
+			}
+
+			return planCheck(conf, ignoreEmpty)
+		},
+	}
+	plancheckCmd.PersistentFlags().BoolVar(&ignoreEmpty, "ignore-empty", false, "Ignore file systems with no snapshots")
+
 	rootCmd.AddCommand(plancheckCmd)
 }
 
-var plancheckCmd = &cobra.Command{
-	Use:   "plancheck [config file]",
-	Short: "Print mounts that have no plan and exit",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("%s /path/to/config.conf", cmd.Name())
-		}
+func hasSnapshots(path string) bool {
+	argsStr := fmt.Sprintf("list -t snapshot -o name %s -H -d 1", path)
+	args := strings.Fields(argsStr)
 
-		confFile, err := os.Open(args[0])
-		if err != nil {
-			return fmt.Errorf("failed to open %s: %s", args[0], err.Error())
-		}
-		defer confFile.Close()
+	output, err := exec.Command(commandName, args...).Output()
+	if err != nil {
+		return false
+	}
 
-		conf, err := readConf(confFile)
-		if err != nil {
-			return err
-		}
-		return planCheck(conf)
-	},
+	return len(output) > 0
 }
 
-func planCheck(conf *conf.Config) error {
+func planCheck(conf *conf.Config, ignoreEmpty bool) error {
 	args := []string{"list", "-t", "filesystem", "-o", "name", "-H"}
 
 	output, err := exec.Command(commandName, args...).Output()
@@ -54,6 +69,10 @@ func planCheck(conf *conf.Config) error {
 
 	for _, store := range strings.Fields(string(output)) {
 		if !m[store] {
+			if ignoreEmpty && !hasSnapshots(store) {
+				continue
+			}
+
 			fmt.Printf("No plan found for path: '%s'\n", store)
 		}
 	}


### PR DESCRIPTION
This makes `plancheck` useful when the user has multiple filesystems, but not using snapshots on all.