### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ A few flags are provided as well.
 |-------|----------------|-------------------------------------------------------------------------------------------|
 | `-n`  | `--dryrun`     | Do nothing, print what could have been done.                                              |
 | `-v`  | `--verbose`    | Do everything, print what's done.                                                         |
+| `-V`  | `--version`    | SHow version and exit (can be used with -v)                                               |

--- a/main.go
+++ b/main.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	verbose = false
-	dryrun  = false
+	verbose     = false
+	dryrun      = false
+	showVersion = false
 
 	commandName      = "/sbin/zfs"
 	commandArguments = []string{"list", "-t", "snapshot", "-o", "name,creation", "-s", "creation", "-r", "-H", "-p"}
@@ -43,6 +44,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&dryrun, "dryrun", "n", false, "Do nothing destructive, only print")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Be more verbose")
+	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "V", false, "Show version and exit")
 	rootCmd.TraverseChildren = true
 }
 
@@ -111,6 +113,10 @@ func main() {
 }
 
 func clean(cmd *cobra.Command, args []string) error {
+	if showVersion {
+		printVersion()
+	}
+
 	if len(args) != 1 {
 		return fmt.Errorf("%s /path/to/config.conf", cmd.Name())
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// version can be overridden at compile time using -ldflags '-X main.Version=...'.
+var version = "dev"
+
+func init() {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version information and exit",
+		RunE: func(_ *cobra.Command, args []string) error {
+			printVersion()
+
+			return nil
+		},
+	}
+
+	rootCmd.AddCommand(versionCmd)
+}
+
+func printVersion() {
+	if verbose {
+		fmt.Printf("zfs-cleaner %s\n", version)
+		fmt.Printf("\nhttps://github.com/cego/zfs-cleaner\n")
+
+		os.Exit(0)
+	}
+
+	fmt.Printf("%s\n", version)
+
+	os.Exit(0)
+}


### PR DESCRIPTION
This PR will add a `version` subcommand.

The standard `-V` and `--version` is also supported.

A Makefile for extracting git tags is also included.

This fixes #16.