### PR TITLE
Add include keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ destroy any snapshot name read from `/etc/zfs-cleaner.protected`.
 
 Path must refer to one of the results from `sudo zfs list -t filesystem -o name`.
 
+#### Including configuration files
+
+A configuration file can include other configuration files using the `include `keyword.
+
+    plan planC {
+        path pool/dataset
+
+        keep 0s for 1h
+        include common.conf
+    }
+
+    include /etc/zfs-cleaner.d/*.conf
+
+`include` is interpreted as a Bash-style glob.
+
 ### Units
 
 All periods consits of a positive integer and a unit. A special case is `0s`

--- a/conf/identifiers.go
+++ b/conf/identifiers.go
@@ -5,6 +5,7 @@ const (
 	keepIdentifier    = "keep"
 	pathIdentifier    = "path"
 	protectIdentifier = "protect"
+	includeIdentifier = "include"
 )
 
 const (

--- a/conf/state_test.go
+++ b/conf/state_test.go
@@ -124,3 +124,43 @@ func TestEndError(t *testing.T) {
 		p.Paths = []string{"/"}
 	}
 }
+
+func TestIncludeFile(t *testing.T) {
+	s := &state{}
+
+	cases := []string{
+		"include /dev/null", // empty file
+	}
+
+	for _, cc := range cases {
+		s.scanner = bufio.NewScanner(strings.NewReader(cc))
+		s.scanLine()
+
+		if s.err != nil {
+			t.Errorf("Failed errored on %s", cc)
+		}
+
+		s.err = nil
+	}
+}
+
+func TestIncludeFileError(t *testing.T) {
+	s := &state{}
+
+	cases := []string{
+		"include /does-not-exists-we-hope", // non existing file
+		"include /dev",                     // directory
+		"include /etc/shadow",              // insufficient permissions
+	}
+
+	for _, cc := range cases {
+		s.scanner = bufio.NewScanner(strings.NewReader(cc))
+		s.scanLine()
+
+		if s.err == nil {
+			t.Errorf("Failed to err on %s", cc)
+		}
+
+		s.err = nil
+	}
+}


### PR DESCRIPTION
This PR will add an `include` keyword. This will be useful for use cases where configuration tooling writes multiple configuration files for multiple pools or paths.